### PR TITLE
Minor typo correction & added fallback image text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Interactive code map for quick visualization and navigation within  code DOM obj
 [![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](http://www.csscript.net/Donation.html)
 ## Overview
 
-This simple extension visualizes the cod DOM objects defined in the active document. This extension is a for of the popular plugin that is available for:
+This simple extension visualizes the code DOM objects defined in the active document. This extension is a for of the popular plugin that is available for:
 * Sublime Text 3 - [Sublime CodeMap plugin](https://github.com/oleg-shilo/sublime-codemap/blob/master/README.md)
 * Notepad++ - [Part of CS-Script.Npp plugin](https://github.com/oleg-shilo/cs-script.npp/blob/master/README.md)
-* Visual Studio - [PyMap (python flavor extension](https://marketplace.visualstudio.com/items?itemName=OlegShilo.PyMap)
+* Visual Studio - [PyMap (python flavor extension)](https://marketplace.visualstudio.com/items?itemName=OlegShilo.PyMap)
 
 The extension functionality is straight forward. Just click the code map item and it will trigger the navigation to the document where the corresponding code element is defined in the document.
 
@@ -31,10 +31,10 @@ _Features_:
 
 The plugin comes with support for TypeScript, Python and Markdown syntax. C# support will come very soon. 
 
-![](https://raw.githubusercontent.com/oleg-shilo/codemap.vscode/master/resources/images/codemap_vscode.gif)
+![codemap_vscode.gif](https://raw.githubusercontent.com/oleg-shilo/codemap.vscode/master/resources/images/codemap_vscode.gif)
 
 ## Adding custom mappers
-The most intriguing plugin's feature is the possibility to extend it to support new even most exotic syntaxes. Read more about the technique in this [Wiki page](https://github.com/oleg-shilo/codemap.vscode/wiki/Adding-custom-mappers). 
+The most intriguing feature is the possibility to extend it to support new even most exotic syntaxes. Read more about the technique in this [Wiki page](https://github.com/oleg-shilo/codemap.vscode/wiki/Adding-custom-mappers). 
 
 If you create mapping rules or dedicated mapper and want to share it with others. Create a pull request or just log the corresponding issue on this project and I will consider including your mapper into the plugin package. 
 
@@ -55,10 +55,10 @@ If you create mapping rules or dedicated mapper and want to share it with others
    In this mode the all nodes are made non-expandable and nesting is expressed via node text indent.
 
    _textMode disabled_<br>
-   ![](https://raw.githubusercontent.com/oleg-shilo/codemap.vscode/master/resources/images/tree_mode.png)
+   ![tree_mode.png](https://raw.githubusercontent.com/oleg-shilo/codemap.vscode/master/resources/images/tree_mode.png)
 
    _textMode enabled_<br>
-   ![](https://raw.githubusercontent.com/oleg-shilo/codemap.vscode/master/resources/images/text_mode.png)
+   ![text_mode.png](https://raw.githubusercontent.com/oleg-shilo/codemap.vscode/master/resources/images/text_mode.png)
    
 
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The plugin comes with support for TypeScript, Python and Markdown syntax. C# sup
 ![codemap_vscode.gif](https://raw.githubusercontent.com/oleg-shilo/codemap.vscode/master/resources/images/codemap_vscode.gif)
 
 ## Adding custom mappers
-The most intriguing feature is the possibility to extend it to support new even most exotic syntaxes. Read more about the technique in this [Wiki page](https://github.com/oleg-shilo/codemap.vscode/wiki/Adding-custom-mappers). 
+The most intriguing feature is the possibility to extend the plugin to support new and even more exotic syntaxes. Read more about the technique in this [Wiki page](https://github.com/oleg-shilo/codemap.vscode/wiki/Adding-custom-mappers). 
 
 If you create mapping rules or dedicated mapper and want to share it with others. Create a pull request or just log the corresponding issue on this project and I will consider including your mapper into the plugin package. 
 


### PR DESCRIPTION
Found a couple grammar/typo fixes and added fallback text so when the images fail to load there is a text description of what should be there, see below:

![codemap-text-image-fallback](https://user-images.githubusercontent.com/3784339/51324396-9f9f0380-1a38-11e9-9b87-bdb71e3ea814.png)

Without the fallback text:

![blankwithnofallback](https://user-images.githubusercontent.com/3784339/51479350-fb7ccb80-1d5b-11e9-866c-dcd239f172b7.png)

Been reading and editing too many documents recently :sweat_smile: 